### PR TITLE
Minor warnings and unused lines

### DIFF
--- a/src/Command/CreateBagCommand.php
+++ b/src/Command/CreateBagCommand.php
@@ -2,10 +2,11 @@
 // src/Command/CreateBagCommand.php
 namespace App\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -13,9 +14,13 @@ use App\Service\IslandoraBagger;
 
 use Psr\Log\LoggerInterface;
 
-class CreateBagCommand extends ContainerAwareCommand
+class CreateBagCommand extends Command
 {
+    use ContainerAwareTrait;
+
     private $params;
+
+    private $logger;
 
     public function __construct(LoggerInterface $logger = null, ParameterBagInterface $params = null)
     {
@@ -78,7 +83,7 @@ class CreateBagCommand extends ContainerAwareCommand
         $this->settings['post_bag_scripts'] = (!isset($this->settings['post_bag_scripts'])) ?
             array() : $this->settings['post_bag_scripts'];
 
-        $islandora_bagger = new IslandoraBagger($this->settings, $this->logger, $this->params, $token);
+        $islandora_bagger = new IslandoraBagger($this->settings, $this->logger, $this->params);
         $bag_dir = $islandora_bagger->createBag($nid, $settings_path, $token);
 
         if ($bag_dir) {

--- a/src/Command/GetQueueCommand.php
+++ b/src/Command/GetQueueCommand.php
@@ -2,17 +2,25 @@
 // src/Command/GetQueueCommand.php
 namespace App\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 use Psr\Log\LoggerInterface;
 
-class GetQueueCommand extends ContainerAwareCommand
+class GetQueueCommand extends Command
 {
+    use ContainerAwareTrait;
+
+    private $params;
+
+    private $logger;
+
+    private $application_directory;
+
     public function __construct(LoggerInterface $logger = null, ParameterBagInterface $params = null)
     {
         // Set in the parameters section of config/services.yaml.
@@ -41,12 +49,11 @@ class GetQueueCommand extends ContainerAwareCommand
         $output_format = $input->getOption('output_format');
 
         if (!file_exists($this->queue_path)) {
-            $this->logger->info("Queue file not found", $details);
+            $this->logger->info("Queue file not found");
             return;
-        } 
+        }
 
         $entries = file($this->queue_path, FILE_IGNORE_NEW_LINES);
-        $num_entries_in_queue = count($entries);
         if (is_null($output_format) || $output_format == 'json') {
             $entries_as_json = json_encode($entries);
             print $entries_as_json;

--- a/src/Service/IslandoraBagger.php
+++ b/src/Service/IslandoraBagger.php
@@ -26,15 +26,17 @@ class IslandoraBagger
      *   The node ID.
      * @param string $settings_path
      *   The path to the settings YAML file passed in from the Create Bag command.
+     * @param string $token
+     *   A JWT token
      *
      * @return string|bool
      *   The path to the Bag if successful, false if unsuccessful.
      *   If Bag is serialized, path includes path and Bag filename.
      *
-     * @throws \whikloj\BagItTools\BagItException
+     * @throws \whikloj\BagItTools\Exceptions\BagItException
      *   Problems creating the bag, adding files or writing to disk.
      */
-    public function createBag($nid, $settings_path, $token)
+    public function createBag(string $nid, string $settings_path, string $token='')
     {
       $this->setDefaults();
 
@@ -112,7 +114,7 @@ class IslandoraBagger
         $bag->update();
         $this->removeDir($bag_temp_dir);
 
-        $package = isset($this->settings['serialize']) ? $this->settings['serialize'] : false;
+        $package = $this->settings['serialize'] ?? false;
         if ($package) {
             $bag_file_path = $this->settings['output_dir'] . DIRECTORY_SEPARATOR . $bag_name  . '.' . $package;
             if (file_exists($bag_file_path)) {
@@ -226,12 +228,12 @@ class IslandoraBagger
      *   The node ID.
      * @param string $bag_name
      *   The Bag name.
-     * @param object $bag
+     * @param \whikloj\BagItTools\Bag $bag
      *  The Bag object.
-     * @param string $token
+     * @param ?string $token
      *  JWT authorization token.
      */
-    protected function registerBagWithIslandora($nid, $bag_name, $bag, $token = NULL)
+    protected function registerBagWithIslandora(string $nid, string $bag_name, Bag $bag, ?string $token = NULL)
     {
         if (!$this->settings['register_bags_with_islandora']) {
           return;
@@ -245,7 +247,7 @@ class IslandoraBagger
         } else {
           $fetch_contents = '';
         }
-   
+
         $post_data = [
             'nid' => $nid,
             'bag_name' => $bag_name,


### PR DESCRIPTION
Just some stuff PHPStorm was noting while looking through the code. This should have no impact on how it runs.

However I haven't tried this in an Islandora, I'm building the playbook for some testing there and will try this after to get a better idea of how it interacts.

`ContainerAwareCommand` is deprecated which is why I switched to `Command` and added the `ContainerAwareTrait`.