### PR TITLE
Draft-ish: Add a file lookup for media file url

### DIFF
--- a/src/Plugin/AddMedia.php
+++ b/src/Plugin/AddMedia.php
@@ -71,7 +71,7 @@ class AddMedia extends AbstractIbPlugin
                         } else {
                             // Get the file's URL from the file entity using the file ID provided by the media entity.
                             $file_client = new \GuzzleHttp\Client();
-                            $file_uri = $this->settings['drupal_base_url'] . '/entity/file/' . $media['field_media_file']['target_id'];
+                            $file_uri = $this->settings['drupal_base_url'] . '/entity/file/' . $media['field_media_file'][0]['target_id'];
                             $file_response = $file_client->request('GET', $file_uri, [
                                 'http_errors' => false,
                                 'headers' => ['Authorization' => 'Bearer ' . $token],

--- a/src/Plugin/AddMedia.php
+++ b/src/Plugin/AddMedia.php
@@ -66,8 +66,21 @@ class AddMedia extends AbstractIbPlugin
                             in_array($term['url'], $this->settings['drupal_media_tags'])) {
                         if (isset($media['field_media_image'])) {
                             $file_url = $media['field_media_image'][0]['url'];
-                        } else {
+                        if (isset($media['field_media_file'])) {
                             $file_url = $media['field_media_file'][0]['url'];
+                        } else {
+                            // Get the file's URL from the file entity using the file ID provided by the media entity.
+                            $file_client = new \GuzzleHttp\Client();
+                            $file_uri = $this->settings['drupal_base_url'] . '/entity/file/' . $media['field_media_file']['target_id'];
+                            $file_response = $file_client->request('GET', $file_uri, [
+                                'http_errors' => false,
+                                'headers' => ['Authorization' => 'Bearer ' . $token],
+                                'query' => ['_format' => 'json']
+                            ]);
+                            $file_status_code = $file_response->getStatusCode();
+                            $file_json = (string) $file_response->getBody();
+                            $file_json = json_decode($file_json, true);
+                            $file_url = $this->settings['drupal_base_url'] . $file_json['uri']['url'];
                         }
                         $filename = $this->getFilenameFromUrl($file_url);
 

--- a/src/Plugin/AddMedia.php
+++ b/src/Plugin/AddMedia.php
@@ -66,7 +66,7 @@ class AddMedia extends AbstractIbPlugin
                             in_array($term['url'], $this->settings['drupal_media_tags'])) {
                         if (isset($media['field_media_image'])) {
                             $file_url = $media['field_media_image'][0]['url'];
-                        } elseif(isset($media['field_media_file'])) {
+                        } elseif (isset($media['field_media_file'][0]['url'])) {
                             $file_url = $media['field_media_file'][0]['url'];
                         } else {
                             // Get the file's URL from the file entity using the file ID provided by the media entity.
@@ -80,7 +80,7 @@ class AddMedia extends AbstractIbPlugin
                             $file_status_code = $file_response->getStatusCode();
                             $file_json = (string) $file_response->getBody();
                             $file_json = json_decode($file_json, true);
-                            $file_url = $this->settings['drupal_base_url'] . $file_json['uri']['url'];
+                            $file_url = $this->settings['drupal_base_url'] . $file_json['uri'][0]['url'];
                         }
                         $filename = $this->getFilenameFromUrl($file_url);
 

--- a/src/Plugin/AddMedia.php
+++ b/src/Plugin/AddMedia.php
@@ -66,7 +66,7 @@ class AddMedia extends AbstractIbPlugin
                             in_array($term['url'], $this->settings['drupal_media_tags'])) {
                         if (isset($media['field_media_image'])) {
                             $file_url = $media['field_media_image'][0]['url'];
-                        if (isset($media['field_media_file'])) {
+                        } elseif(isset($media['field_media_file'])) {
                             $file_url = $media['field_media_file'][0]['url'];
                         } else {
                             // Get the file's URL from the file entity using the file ID provided by the media entity.


### PR DESCRIPTION
## I DO NOT KNOW IF THIS WILL WORK.
This is untested.

I wrote this without having it installed locally. This came from a conversation from slack https://islandora.slack.com/archives/C019U12D44Q/p1674063587768829

# The problem
Curl a media object, and it doesn't return the expected `$media['field_media_file'][0]['url']`
`curl -i -X GET 'https://sandbox.islandora.ca/media/107?_format=json'`

In [AddMedia Line 67-71](https://github.com/mjordan/islandora_bagger/blob/main/src/Plugin/AddMedia.php#L67-L71) it does an "if" statement but not a lookup. 

This PR shows a possible solution. It extends the checks, and the fallback does an entity file lookup from the media. 

Sorry, in advance. I didn't review this module or test this code to see if it works prior to submitting the PR. I hope this helps in either providing a solution or clarity to the person reporting the initial issue in Slack. 